### PR TITLE
Fixed issue 125 [Checking both on client and server]

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -49,7 +49,7 @@ exports = module.exports = function(app) {
 
     if(process.env.RECRUTAMENTO == "true"){
         app.get('/candidatura',middleware.nonUser,routes.views.candidatura);
-        app.post('/candidatura',middleware.nonUser,routes.views.candidatura.create);
+        app.post('/candidatura',middleware.nonUser, middleware.validarCandidatura, routes.views.candidatura.create);
     }
 
     app.get('/entrevistas',middleware.nonRecruta,routes.views.entrevistas);

--- a/routes/index.js
+++ b/routes/index.js
@@ -49,7 +49,7 @@ exports = module.exports = function(app) {
 
     if(process.env.RECRUTAMENTO == "true"){
         app.get('/candidatura',middleware.nonUser,routes.views.candidatura);
-        app.post('/candidatura',middleware.nonUser, middleware.validarCandidatura, routes.views.candidatura.create);
+        app.post('/candidatura',middleware.nonUser, middleware.validateApplication, routes.views.candidatura.create);
     }
 
     app.get('/entrevistas',middleware.nonRecruta,routes.views.entrevistas);

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -89,7 +89,7 @@ exports.nonRecruta = function(req, res, next) {
 };
 
 //TODO fazer a validação do lado do servidor dos dados da candidatura
-exports.validarCandidatura = function(req, res, next) {
+exports.validateApplication = function(req, res, next) {
   let currYear = req.body.ano_curricular;
   if(currYear >= 1) {
       next();

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -90,7 +90,14 @@ exports.nonRecruta = function(req, res, next) {
 
 //TODO fazer a validação do lado do servidor dos dados da candidatura
 exports.validarCandidatura = function(req, res, next) {
-  next();
+  let currYear = req.body.ano_curricular;
+  if(currYear >= 1) {
+      next();
+  } else {
+    req.flash('warning','O Ano Curricular tem de ser positivo.');
+    res.redirect('/candidatura');
+  }
+
 };
 
 exports.User_Password = function(req, res, next) {

--- a/templates/views/candidatura.pug
+++ b/templates/views/candidatura.pug
@@ -40,7 +40,7 @@ block content
             //.flex
               i.fa.fa-id-card.fa-icon
               label(for='numero up') Ano Curricular:
-            input#field.form-control(type='number', placeholder='Ano Curricular*' name='ano_curricular' required)
+            input#field.form-control(type='number', placeholder='Ano Curricular*' name='ano_curricular' required, min='1')
           div.form-group
             //.flex
               i.fa.fa-envelope.fa-icon


### PR DESCRIPTION
Dei fix ao problema de um candidato poder escolher ano curricular < 1. A verificação é feita no cliente e no servidor. No cliente, se estiver menor que 1, n deixa submeter e manda um warning à beira do campo. No servidor, é mais para ser mesmo seguro. Se receber um ano < 1, manda flash message (warning) e da redirect para a página das candidaturas.

Testei as duas versões (cliente e servidor) e no cliente funcionou como descrito, no servidor emulei um request no dev tools do mozilla e deu erro, mas nao deu redirect, sendo q da próxima vez q fui a /candidatura apareceu a a flash message (warning).

Uma vez que não é possivel um client mandar <1 pelo form normalmente, e como pelas dev tools ele não faz redirect, pode-se tirar a flash message pois da próxima vez que aparece já não faz sentido.