### PR TITLE
Fix missing member external links

### DIFF
--- a/src/public/styles/site/_members.scss
+++ b/src/public/styles/site/_members.scss
@@ -147,9 +147,6 @@
         left: 15px;
         overflow: hidden;
         transition: 0.75s ease;
-        @media (max-width: 991px) and (min-width: 768px) {
-            display: none;
-        }
         a {
             font-size: 20px;
             @media (min-width: 768px) {


### PR DESCRIPTION
Closes #186 

External links on member cards were missing in the range 768px to 991px.

The following screenshots identify the behavior after updating (the card on the right is the one being hovered):

#### width > 991px

![image](https://user-images.githubusercontent.com/25830462/95056740-0ffa2680-06ed-11eb-9f06-5b19fa5e8e10.png)

#### width > 768px && width <= 991px

![image](https://user-images.githubusercontent.com/25830462/95056807-26a07d80-06ed-11eb-9fa9-eb20aeba8d19.png)
