### PR TITLE
fix: avoid doing lots of reconnection attempts

### DIFF
--- a/src/keystone.js
+++ b/src/keystone.js
@@ -32,8 +32,8 @@ keystone.init({
 	"mongo options": {
 		
 		keepAlive: 1,
-		reconnectTries: Number.MAX_VALUE,
-		reconnectInterval: 1500,
+		reconnectTries: 24 * 60, // 1 day at 60s intervals
+		reconnectInterval: 60000,
 	},
 });
 


### PR DESCRIPTION
This PR limits the ammount of reconnections to the db to 1440 at 60s between reconnections. This means the server will spend, at most, one day trying to reconnect to the db.

On an 8-core machine, this will limit the number of reconnection attempts from 460.8k per day to 11.52k.